### PR TITLE
Remove critical dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-only"
 name = "navitia-poi-model"
 readme = "README.md"
 repository = "https://github.com/CanalTP/navitia-poi-model.git"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 categories = ["data-structures", "parser-implementations"]
 description = "Navitia's POIs (Point of Interest) model"
-edition = "2021"
+edition = "2018"
 keywords = ["data", "osm", "transit"]
 license = "AGPL-3.0-only"
 name = "navitia-poi-model"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 categories = ["data-structures", "parser-implementations"]
 description = "Navitia's POIs (Point of Interest) model"
-edition = "2018"
+edition = "2021"
 keywords = ["data", "osm", "transit"]
 license = "AGPL-3.0-only"
 name = "navitia-poi-model"
@@ -11,8 +11,8 @@ repository = "https://github.com/CanalTP/navitia-poi-model.git"
 version = "0.4.0"
 
 [dependencies]
+anyhow = "1"
 csv = "1"
-failure = "0.1"
 geo = "0.18"
 itertools = "0.10"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ failure = "0.1"
 geo = "0.18"
 itertools = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-zip = "0.5"
+zip = { version = "0.5", default_features = false }

--- a/src/io.rs
+++ b/src/io.rs
@@ -14,7 +14,7 @@
 
 use crate::Result;
 use crate::{Coord, Model, Poi, PoiType, Property};
-use failure::format_err;
+use anyhow::anyhow;
 use itertools::Itertools;
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::{BTreeMap, HashMap};
@@ -99,7 +99,7 @@ where
         read_csv(zipper).try_for_each::<_, Result<_>>(|rec| {
             let poi_property: PoiProperty = rec?;
             let poi = pois.get_mut(&poi_property.poi_id).ok_or_else(|| {
-                format_err!(
+                anyhow!(
                     "in file '{}', cannot find poi '{}' for property insertion",
                     path.as_ref().display(),
                     &poi_property.poi_id
@@ -256,5 +256,5 @@ where
         .from_reader(reader);
     csv_reader
         .into_deserialize()
-        .map(|e| e.map_err(|e| format_err!("err {}", e)))
+        .map(|e| e.map_err(|e| anyhow!("err {}", e)))
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -254,7 +254,8 @@ where
     let csv_reader = csv::ReaderBuilder::new()
         .delimiter(b';')
         .from_reader(reader);
+
     csv_reader
         .into_deserialize()
-        .map(|e| e.map_err(|e| anyhow!("err {}", e)))
+        .map(|line| line.map_err(Into::into))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub mod objects;
 pub use objects::*;
 
 /// The data type for errors in [navitia-poi-model], just an alias
-pub type Error = failure::Error;
+pub type Error = anyhow::Error;
 
 /// The classic alias for result type.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -21,7 +21,7 @@
 //!
 
 use crate::{io, Result};
-use failure::format_err;
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::collections::{
     btree_map::Entry as BTreeMapEntry, hash_map::Entry as HashMapEntry, BTreeMap, HashMap,
@@ -165,10 +165,9 @@ impl Model {
             .pois
             .into_iter()
             .try_fold(self.pois, |mut acc, (k, v)| match acc.entry(k) {
-                BTreeMapEntry::Occupied(entry) => Err(format_err!(
-                    "POI with id {} already in the model",
-                    entry.key()
-                )),
+                BTreeMapEntry::Occupied(entry) => {
+                    Err(anyhow!("POI with id {} already in the model", entry.key()))
+                }
                 BTreeMapEntry::Vacant(entry) => {
                     entry.insert(v);
                     Ok(acc)
@@ -184,7 +183,7 @@ impl Model {
                         if *entry.get() == v {
                             Ok(acc) // If the poi_types in both map are identical (id and label), it's ok
                         } else {
-                            Err(format_err!(
+                            Err(anyhow!(
                                 "Trying to override POI Type with id {}",
                                 entry.key()
                             ))

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -21,7 +21,6 @@
 //!
 
 use crate::{io, Result};
-use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use std::collections::{
     btree_map::Entry as BTreeMapEntry, hash_map::Entry as HashMapEntry, BTreeMap, HashMap,
@@ -166,7 +165,7 @@ impl Model {
             .into_iter()
             .try_fold(self.pois, |mut acc, (k, v)| match acc.entry(k) {
                 BTreeMapEntry::Occupied(entry) => {
-                    Err(anyhow!("POI with id {} already in the model", entry.key()))
+                    anyhow::bail!("POI with id {} already in the model", entry.key())
                 }
                 BTreeMapEntry::Vacant(entry) => {
                     entry.insert(v);
@@ -183,10 +182,7 @@ impl Model {
                         if *entry.get() == v {
                             Ok(acc) // If the poi_types in both map are identical (id and label), it's ok
                         } else {
-                            Err(anyhow!(
-                                "Trying to override POI Type with id {}",
-                                entry.key()
-                            ))
+                            anyhow::bail!("Trying to override POI Type with id {}", entry.key())
                         }
                     }
                     HashMapEntry::Vacant(entry) => {


### PR DESCRIPTION
Dependencies are still up to date in this repository, but `cargo audit` still raised issues:

 - `zip` relies on an outdated version of `time` that may segfault: https://rustsec.org/advisories/RUSTSEC-2020-0071, it doesn't seem to affect us as an optional feature that we don't use, but we can still spare a few dependencies and eliminate the risk by disabling it
 - `failure` is unmaintained, I replaced it with the close equivalent `anyhow`