### PR TITLE
[fix] bump version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-only"
 name = "navitia-poi-model"
 readme = "README.md"
 repository = "https://github.com/CanalTP/navitia-poi-model.git"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
the last PR introduced a breaking change and we went from version 0.4.0 to 0.4.1 instead of 0.5.0

see https://github.com/CanalTP/navitia-poi-model/commit/1657c474845c3541388f0475f11f76c17b0ac5af#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R25
